### PR TITLE
Deprecate repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
+This project is no longer actively developed or maintained.
+
+For other App Engine samples, check out [python-docs-samples/appengine](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/appengine)
+
+
 # appengine-mandelbrot-python
 
 A simple example app showing how to dynamically generate animated


### PR DESCRIPTION
While the sample is still valid, it's old enough that moving it to archive makes sense, since it can still be accessed there.
